### PR TITLE
Fix slash/question mark key binding in Z row

### DIFF
--- a/BlankApp2/Views/MainWindow.xaml
+++ b/BlankApp2/Views/MainWindow.xaml
@@ -241,7 +241,7 @@
             <ContentControl Content="{Binding MyKeyStatusList[VK_M]}"/>
             <ContentControl Content="{Binding MyKeyStatusList[VK_BC]}"/>
             <ContentControl Content="{Binding MyKeyStatusList[VK_BE]}"/>
-            <ContentControl Content="{Binding MyKeyStatusList[VK_BE]}"/>
+            <ContentControl Content="{Binding MyKeyStatusList[VK_BF]}"/>
             <ContentControl Content="{Binding MyKeyStatusList[VK_BF]}" Tag="VK_RSHIFT"/>
         </StackPanel>
 


### PR DESCRIPTION
## Summary
- Correct `/ ?` key binding to use `VK_BF` instead of `VK_BE` in Z row

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6891e36cb808832d970ffc7b49b902ba