### PR TITLE
Add unit tests for capture start/stop commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: .NET
+
+on:
+  push:
+    branches: [ "master", "work" ]
+  pull_request:
+    branches: [ "master", "work" ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore KeyboardApp.sln
+    - name: Build
+      run: dotnet build KeyboardApp.sln --no-restore
+    - name: Test
+      run: dotnet test KeyboardApp.sln --no-build --verbosity normal

--- a/BlankApp2.Tests/BlankApp2.Tests.csproj
+++ b/BlankApp2.Tests/BlankApp2.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BlankApp2\KeyboardApp.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+  </ItemGroup>
+</Project>

--- a/BlankApp2.Tests/MainWindowViewModelTests.cs
+++ b/BlankApp2.Tests/MainWindowViewModelTests.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using KeyBoardApp;
+using KeyBoardApp.ViewModels;
+
+namespace BlankApp2.Tests
+{
+    [TestClass]
+    public class MainWindowViewModelTests
+    {
+        [TestMethod]
+        public void CmdCaptureStart_ClearsHistoryAndEnablesCapture()
+        {
+            var vm = new MainWindowViewModel();
+            vm.KeyHist.Add((new KeyDto(), TimeSpan.Zero));
+            vm.MouseHist.Add((new MouseDto(), TimeSpan.Zero));
+
+            vm.CmdCaptureStart.Execute();
+
+            Assert.IsTrue(vm.IsCapture);
+            Assert.AreEqual(0, vm.KeyHist.Count);
+            Assert.AreEqual(0, vm.MouseHist.Count);
+        }
+
+        [TestMethod]
+        public void CmdCaptureStop_DisablesCapture()
+        {
+            var vm = new MainWindowViewModel();
+            vm.CmdCaptureStart.Execute();
+
+            vm.CmdCaptureStop.Execute();
+
+            Assert.IsFalse(vm.IsCapture);
+        }
+    }
+}

--- a/KeyboardApp.sln
+++ b/KeyboardApp.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.31515.178
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KeyboardApp", "BlankApp2\KeyboardApp.csproj", "{17FD079C-5756-47EA-8DC9-8D530941DF1A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlankApp2.Tests", "BlankApp2.Tests\BlankApp2.Tests.csproj", "{C32FF4B9-C0D0-4F49-A79B-1F0280390A18}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{17FD079C-5756-47EA-8DC9-8D530941DF1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{17FD079C-5756-47EA-8DC9-8D530941DF1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{17FD079C-5756-47EA-8DC9-8D530941DF1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C32FF4B9-C0D0-4F49-A79B-1F0280390A18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C32FF4B9-C0D0-4F49-A79B-1F0280390A18}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C32FF4B9-C0D0-4F49-A79B-1F0280390A18}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C32FF4B9-C0D0-4F49-A79B-1F0280390A18}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add MSTest project for `MainWindowViewModel`
- verify capture start clears history and enables capture
- ensure capture stop disables capture
- run tests in GitHub Actions on Windows

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891e613517c832d8706111bfcdb11bb